### PR TITLE
Flag to automatically cluster pins & fix to marker moving when clicked

### DIFF
--- a/src/Xamarin.Forms.GoogleMaps.Android.Utils/Xamarin.Forms.GoogleMaps.Android.Utils.csproj
+++ b/src/Xamarin.Forms.GoogleMaps.Android.Utils/Xamarin.Forms.GoogleMaps.Android.Utils.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -110,7 +109,6 @@
   <Import Project="..\packages\Xamarin.Android.Support.Media.Compat.25.1.1\build\MonoAndroid70\Xamarin.Android.Support.Media.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Media.Compat.25.1.1\build\MonoAndroid70\Xamarin.Android.Support.Media.Compat.targets')" />
   <Import Project="..\packages\Xamarin.Android.Support.Fragment.25.1.1\build\MonoAndroid70\Xamarin.Android.Support.Fragment.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Fragment.25.1.1\build\MonoAndroid70\Xamarin.Android.Support.Fragment.targets')" />
   <Import Project="..\packages\Xamarin.Android.Support.v4.25.1.1\build\MonoAndroid70\Xamarin.Android.Support.v4.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v4.25.1.1\build\MonoAndroid70\Xamarin.Android.Support.v4.targets')" />
-  
   <Import Project="..\packages\Xamarin.Build.Download.0.4.11\build\Xamarin.Build.Download.targets" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.11\build\Xamarin.Build.Download.targets')" />
   <Import Project="..\packages\Xamarin.GooglePlayServices.Basement.42.1021.1\build\MonoAndroid70\Xamarin.GooglePlayServices.Basement.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Basement.42.1021.1\build\MonoAndroid70\Xamarin.GooglePlayServices.Basement.targets')" />
   <Import Project="..\packages\Xamarin.GooglePlayServices.Tasks.42.1021.1\build\MonoAndroid70\Xamarin.GooglePlayServices.Tasks.targets" Condition="Exists('..\packages\Xamarin.GooglePlayServices.Tasks.42.1021.1\build\MonoAndroid70\Xamarin.GooglePlayServices.Tasks.targets')" />

--- a/src/Xamarin.Forms.GoogleMaps.Clustering.Android/ClusterLogic.cs
+++ b/src/Xamarin.Forms.GoogleMaps.Clustering.Android/ClusterLogic.cs
@@ -206,13 +206,17 @@ namespace Xamarin.Forms.GoogleMaps.Clustering.Android
         protected override void AddItems(IList newItems)
         {
             base.AddItems(newItems);
-            clusterManager.Cluster();
+
+            if (ClusteredMap.ClusterOptions.AutoClusterAfterAddingPin)
+                clusterManager.Cluster();
         }
 
         protected override void RemoveItems(IList oldItems)
         {
             base.RemoveItems(oldItems);
-            clusterManager.Cluster();
+
+            if (ClusteredMap.ClusterOptions.AutoClusterAfterAddingPin)
+                clusterManager.Cluster();
         }
 
         protected override void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Xamarin.Forms.GoogleMaps.Clustering.Android/ClusterLogic.cs
+++ b/src/Xamarin.Forms.GoogleMaps.Clustering.Android/ClusterLogic.cs
@@ -304,10 +304,14 @@ namespace Xamarin.Forms.GoogleMaps.Clustering.Android
                 var factory = bitmapDescriptorFactory ?? DefaultBitmapDescriptorFactory.Instance;
                 var nativeDescriptor = factory.ToNative(outerItem.Icon);
                 nativeItem.Icon = nativeDescriptor;
+                
+                // The values of AnchorX: 0.5f and AnchorY: 0.5f move the marker to the upperleft.
+                // 0.5 and 1.0 make it stay in the same spot.
                 nativeItem.AnchorX = 0.5f;
-                nativeItem.AnchorY = 0.5f;
+                nativeItem.AnchorY = 1.0f;
+
                 nativeItem.InfoWindowAnchorX = 0.5f;
-                nativeItem.InfoWindowAnchorY = 0.5f;
+                nativeItem.InfoWindowAnchorY = 1.0f;
             }
         }
 

--- a/src/Xamarin.Forms.GoogleMaps.Clustering.Android/ClusterLogic.cs
+++ b/src/Xamarin.Forms.GoogleMaps.Clustering.Android/ClusterLogic.cs
@@ -206,17 +206,13 @@ namespace Xamarin.Forms.GoogleMaps.Clustering.Android
         protected override void AddItems(IList newItems)
         {
             base.AddItems(newItems);
-
-            if (ClusteredMap.ClusterOptions.AutoClusterAfterAddingPin)
-                clusterManager.Cluster();
+            clusterManager.Cluster();
         }
 
         protected override void RemoveItems(IList oldItems)
         {
             base.RemoveItems(oldItems);
-
-            if (ClusteredMap.ClusterOptions.AutoClusterAfterAddingPin)
-                clusterManager.Cluster();
+            clusterManager.Cluster();
         }
 
         protected override void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Xamarin.Forms.GoogleMaps.Clustering.Android/Xamarin.Forms.GoogleMaps.Clustering.Android.csproj
+++ b/src/Xamarin.Forms.GoogleMaps.Clustering.Android/Xamarin.Forms.GoogleMaps.Clustering.Android.csproj
@@ -16,8 +16,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Xamarin.Forms.GoogleMaps.Clustering.iOS/ClusterLogic.cs
+++ b/src/Xamarin.Forms.GoogleMaps.Clustering.iOS/ClusterLogic.cs
@@ -160,17 +160,13 @@ namespace Xamarin.Forms.GoogleMaps.Clustering.iOS
         protected override void AddItems(IList newItems)
         {
             base.AddItems(newItems);
-
-            if (ClusteredMap.ClusterOptions.AutoClusterAfterAddingPin)
-                clusterManager.Cluster();
+            clusterManager.Cluster();
         }
 
         protected override void RemoveItems(IList oldItems)
         {
             base.RemoveItems(oldItems);
-
-            if (ClusteredMap.ClusterOptions.AutoClusterAfterAddingPin)
-                clusterManager.Cluster();
+            clusterManager.Cluster();
         }
         
         protected override void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Xamarin.Forms.GoogleMaps.Clustering.iOS/ClusterLogic.cs
+++ b/src/Xamarin.Forms.GoogleMaps.Clustering.iOS/ClusterLogic.cs
@@ -160,13 +160,17 @@ namespace Xamarin.Forms.GoogleMaps.Clustering.iOS
         protected override void AddItems(IList newItems)
         {
             base.AddItems(newItems);
-            clusterManager.Cluster();
+
+            if (ClusteredMap.ClusterOptions.AutoClusterAfterAddingPin)
+                clusterManager.Cluster();
         }
 
         protected override void RemoveItems(IList oldItems)
         {
             base.RemoveItems(oldItems);
-            clusterManager.Cluster();
+
+            if (ClusteredMap.ClusterOptions.AutoClusterAfterAddingPin)
+                clusterManager.Cluster();
         }
         
         protected override void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Xamarin.Forms.GoogleMaps.Clustering/ClusterOptions.cs
+++ b/src/Xamarin.Forms.GoogleMaps.Clustering/ClusterOptions.cs
@@ -13,6 +13,17 @@ namespace Xamarin.Forms.GoogleMaps.Clustering
         public ClusterAlgorithm Algorithm { get; set; }
 
         /// <summary>
+        /// Gets or sets whether the pins are clustered automatically after a new one is added.
+        /// </summary>
+        /// <value><c>true</c> (default) if enabled, automatically clusters; otherwise, <c>false</c>.</value>
+        /// <example>
+        /// The cluster function is called every time a new pin is added to the map so the displayed pins are updated. 
+        /// Setting this property to false won't call the cluster function, and so map pins won't be updated until Cluster() is manually called on your map object.
+        /// Default (true) is recommended. Moving the camera or changing the zoom level updates the pins regardless.
+        /// </example>
+        public bool AutoClusterAfterAddingPin { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="T:Xamarin.Forms.GoogleMaps.Clustering.ClusterOptions"/> enable buckets grouping.
         /// </summary>
         /// <value><c>true</c> if enable buckets; otherwise, <c>false</c>.</value>

--- a/src/Xamarin.Forms.GoogleMaps.Clustering/ClusterOptions.cs
+++ b/src/Xamarin.Forms.GoogleMaps.Clustering/ClusterOptions.cs
@@ -13,17 +13,6 @@ namespace Xamarin.Forms.GoogleMaps.Clustering
         public ClusterAlgorithm Algorithm { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the pins are clustered automatically after a new one is added.
-        /// </summary>
-        /// <value><c>true</c> (default) if enabled, automatically clusters; otherwise, <c>false</c>.</value>
-        /// <example>
-        /// The cluster function is called every time a new pin is added or removed from the map so the displayed pins are updated. 
-        /// Setting this property to false won't call the cluster function, and so map pins won't be updated until Cluster() is manually called on your map object.
-        /// Default (true) is recommended. Moving the camera or changing the zoom level updates the pins regardless.
-        /// </example>
-        public bool AutoClusterAfterAddingPin { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="T:Xamarin.Forms.GoogleMaps.Clustering.ClusterOptions"/> enable buckets grouping.
         /// </summary>
         /// <value><c>true</c> if enable buckets; otherwise, <c>false</c>.</value>

--- a/src/Xamarin.Forms.GoogleMaps.Clustering/ClusterOptions.cs
+++ b/src/Xamarin.Forms.GoogleMaps.Clustering/ClusterOptions.cs
@@ -13,6 +13,17 @@ namespace Xamarin.Forms.GoogleMaps.Clustering
         public ClusterAlgorithm Algorithm { get; set; }
 
         /// <summary>
+        /// Gets or sets whether the pins are clustered automatically after a new one is added.
+        /// </summary>
+        /// <value><c>true</c> (default) if enabled, automatically clusters; otherwise, <c>false</c>.</value>
+        /// <example>
+        /// The cluster function is called every time a new pin is added or removed from the map so the displayed pins are updated. 
+        /// Setting this property to false won't call the cluster function, and so map pins won't be updated until Cluster() is manually called on your map object.
+        /// Default (true) is recommended. Moving the camera or changing the zoom level updates the pins regardless.
+        /// </example>
+        public bool AutoClusterAfterAddingPin { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="T:Xamarin.Forms.GoogleMaps.Clustering.ClusterOptions"/> enable buckets grouping.
         /// </summary>
         /// <value><c>true</c> if enable buckets; otherwise, <c>false</c>.</value>


### PR DESCRIPTION
Included in this pull request are the concerns raised on the following issues: #40 and #41.

With a proper explanation and the default being true, I don't think the clustering flag will be too confusing for future users.

Markers moving is a simple fix. Examples are on the relevant issue.