### PR TITLE
I've fixed the unneeded "+" sign

### DIFF
--- a/src/Xamarin.Forms.GoogleMaps.Clustering.Android/ClusterRenderer.cs
+++ b/src/Xamarin.Forms.GoogleMaps.Clustering.Android/ClusterRenderer.cs
@@ -131,9 +131,12 @@ namespace Xamarin.Forms.GoogleMaps.Clustering.Android
 
         private string GetClusterText(ICluster cluster)
         {
-            string result;
-            var size = cluster.Size;
+            return GetClusterText(cluster.Size);
+        }
 
+        protected override string GetClusterText(int size)
+        {
+            string result;
             if (map.ClusterOptions.EnableBuckets)
             {
                 var buckets = map.ClusterOptions.Buckets;

--- a/src/Xamarin.Forms.GoogleMaps.Clustering.iOS/ClusterIconGeneratorHandler.cs
+++ b/src/Xamarin.Forms.GoogleMaps.Clustering.iOS/ClusterIconGeneratorHandler.cs
@@ -28,9 +28,9 @@ namespace Xamarin.Forms.GoogleMaps.Clustering.iOS
             {
                 var buckets = options.Buckets;
                 bucketIndex = BucketIndexForSize((nint)size);
-
                 text = size < (nuint)buckets[0] ? size.ToString() : $"{buckets[bucketIndex]}+";
             }
+            else text = size.ToString();
 
             if (options.RendererCallback != null)
                 return DefaultImageFactory.Instance.ToUIImage(options.RendererCallback(text));


### PR DESCRIPTION
For example with the next options:```


            map.ClusterOptions.EnableBuckets = true;
            map.ClusterOptions.Algorithm = Xamarin.Forms.GoogleMaps.Clustering.ClusterAlgorithm.NonHierarchicalDistanceBased;
            map.ClusterOptions.SetBuckets(
                new int[] { 30 },
                new Color[] { Color.FromHex("#0A203D") });
```

I only have one bucket > 30.

So i would expect that 1 til 29 clusters doesn't get the + sign because it's not in the bucket.. then after 30 it's all 30+